### PR TITLE
More default health files and make friendly

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,7 @@
 # Code of Conduct
 
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
+<img src="https://openmoji.org/data/color/svg/1F984.svg" alt="Unicorn Unicode 1F984. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
+
 The OpenGitOps community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
+<img src="https://openmoji.org/data/color/svg/1F91D.svg" alt="Handshake emoji Unicode 1F91D. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
+
+There are many ways to contribute to OpenGitOps.
+See [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved) in the GitOps WG.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# .github
+# OpenGitOps Default Community Health Files
+
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
+<img src="https://openmoji.org/data/color/svg/1F9D1-200D-2695-FE0F.svg" alt="Health Worker Unicode 1F9D1-200D-2695-FE0F. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
 
 This repo contains organization-wide [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for all CNCF OpenGitOps project repos

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Please do not report vulnerabily details for other projects to the OpenGitOps ma
 | Name | GitHub | Key URL | Fingerprint |
 | -- | -- | -- | -- |
 | Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
-
+| Dan Garfield | [@todaywasawesome](https://github.com/todaywasawesome) | <https://keybase.io/dangarfield/pgp_keys.asc> | EDD6 6C22 E665 61FE |
 ## Handling
 
 - All reports will be thoroughly investigated by the OpenGitOps maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# OpenGitOps Security
+
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
+<img src="https://openmoji.org/data/color/svg/1F510.svg" alt="Lock With Key Unicode 1F510. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
+
+This document defines security reporting, handling, and disclosure information for the OpenGitOps project and community.
+
+## Reporting
+
+We're very thankful for – and if desired happy to credit – security researchers and users who report vulnerabilities to the OpenGitOps community.
+
+To report a security issue directlly related to the OpenGitOps project:
+
+- Please email the private maintainers list <cncf-opengitops-maintainers@lists.cncf.io> with the details.
+- You may, but are not required to, encrypt your email to this list using the PGP keys of OpenGitOps maintainers, listed below.
+- You may choose if you want public acknowledgement of your effort and how you would like to be credited.
+
+⚠️ If a vulnerability is for a specific project, tool or service in the wider GitOps ecosystem, please report directly to the security team for that specific project.
+If you are unsure how to contact the security team for a specific project, you may send us a request for that info and we will do our best to help direct you.
+Please do not report vulnerabily details for other projects to the OpenGitOps maintainers.
+
+## Maintainer PGP Keys
+
+| Name | GitHub | Key URL | Fingerprint |
+| -- | -- | -- | -- |
+| Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
+
+## Handling
+
+- All reports will be thoroughly investigated by the OpenGitOps maintainers.
+- Any vulnerability information shared with the OpenGitOps maintainers will not be shared with others unless it is necessary to fix the issue.
+  Information is shared only on a need to know basis.
+- As the security issue moves through the identification and resolution process, the reporter will be notified.
+- Additional questions about the vulnerability may also be asked of the reporter.
+
+## Disclosures
+
+Vulnerability disclosures will be listed as [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories) on the appropriate OpenGitOps repository and announced publicly.
+Disclosures will contain an overview, details about the vulnerability, a fix that will typically be an update, and optionally a workaround if one is available.
+
+We prefer to fully disclose a vulnerability as soon as possible once a user mitigation is available.
+Disclosures will be published on the same day as a release fixing the vulnerability, after the release is published.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD033 -->
 <p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
-<img src="https://openmoji.org/data/color/svg/1F481.svg" alt="Person Tipping Hand Unicode 1F481. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
+<img src="https://openmoji.org/data/color/svg/1F919.svg" alt="Call Me Hand Unicode 1F919. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
 
 The success and happiness of all users is essential to the OpenGitOps community.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# OpenGitOps Support
+
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150" valign="middle">
+<img src="https://openmoji.org/data/color/svg/1F481.svg" alt="Person Tipping Hand Unicode 1F481. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
+
+The success and happiness of all users is essential to the OpenGitOps community.
+
+## General Information
+
+- See [OpenGitOps Documents](https://github.com/open-gitops/documents)
+- and the [GitHub Working Group](https://github.com/gitops-working-group/gitops-working-group)
+
+## Communication
+
+- To report security vulnerabilities, please see [SUPPORT.md](SUPPORT.md)
+- To connect with the GitHub Working Group – including Reddit, Slack, public email list, GitHub issues, and in-person meeting info – see [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved).
+- For all other issues, please open a GitHub issue in the appropriate OpenGitOps repository.
+  If you are unsure which repository to add the issue you may email the OpenGitOps private maintainers list <cncf-opengitops-maintainers@lists.cncf.io> and we'll do our best to help direct you 🙂

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,7 +13,7 @@ The success and happiness of all users is essential to the OpenGitOps community.
 
 ## Communication
 
-- To report security vulnerabilities, please see [SUPPORT.md](SUPPORT.md)
+- To report security vulnerabilities, please see [SECURITY.md](SECURITY.md)
 - To connect with the GitHub Working Group – including Reddit, Slack, public email list, GitHub issues, and in-person meeting info – see [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved).
 - For all other issues, please open a GitHub issue in the appropriate OpenGitOps repository.
   If you are unsure which repository to add the issue you may email the OpenGitOps private maintainers list <cncf-opengitops-maintainers@lists.cncf.io> and we'll do our best to help direct you 🙂


### PR DESCRIPTION
Added other GitHub-supported [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

Also tried to add some friendliness with OpenMoji (they're properly licensed). WDYT?

PR branch preview: https://github.com/open-gitops/.github/tree/more-default-health-files

- `SECURITY.md` is there in advance of any code. Security issues can also be non-code (for example, something within documentation, an accidentally checked-in sensitive file, etc).
- Would other maintainers like to list their PGP keys for optional end user security email encryption?
    - My thinking on adding this was it's probably premature to form a security team since we don’t have any code yet (for interoperability, etc). But it’s not too early to have a note on security (since we are now adding documents), and to follow best practices it's a good idea to give end users a way to encrypt their emails to us about anything security-related.
- I didn't want to repeat too much `CONTRIBUTING` info for now. We can always iterate. Unless you have other ideas