### PR TITLE
Update contributing and support default community health files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,30 @@
 <img src="https://openmoji.org/data/color/svg/1F91D.svg" alt="Handshake emoji Unicode 1F91D. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
 
 There are many ways to contribute to OpenGitOps.
-See [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved) in the GitOps WG.
+Not all contributions are code.
+
+## 👀 Watch
+
+- [Star](https://docs.github.com/en/github/getting-started-with-github/exploring-projects-on-github/saving-repositories-with-stars) and [watch](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications) the [OpenGitOps Documents](https://github.com/open-gitops/documents) and [OpenGitOps Project](https://github.com/open-gitops/project) repos to follow progress
+
+## 💬 Discuss
+
+- Contribute to [OpenGitOps Discussions](https://github.com/open-gitops/project/discussions), including [“How do you use GitOps?”](https://github.com/open-gitops/project/discussions/25)
+- Participate in GitHub Working Group [in-person meetings, Slack, public email list, and social media](https://github.com/cncf/tag-app-delivery/tree/master/gitops-wg#community)
+
+## ✍️ Pull
+
+- Everyone is welcome to make pull requests against any OpenGitOps repo.
+  For example, add your GitOps events to the [GitOps website repo](https://github.com/open-gitops/website) to be listed on <https://opengitops.dev/events>
+- It is encouraged to [discuss](#discuss) your intentions and interests before putting work into pull requests.
+  This makes the experience nicer for yourself and all involved
+
+## 🦄 Play nice
+
+- Please see the community [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## 📑 Licenses and Copyright
+
+- Developer Certificate of Origin (DCO) commit signoff is required for all contributions
+- Additionally all OpenGitOps repos have their own license information, and by default follow:
+<https://github.com/open-gitops/project/blob/main/LICENSE.md>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,12 +8,14 @@ The success and happiness of all users is essential to the OpenGitOps community.
 
 ## General Information
 
-- See [OpenGitOps Documents](https://github.com/open-gitops/documents)
-- and the [GitHub Working Group](https://github.com/gitops-working-group/gitops-working-group)
+- [OpenGitOps Documents](https://github.com/open-gitops/documents)
+- [OpenGitOps Project](https://github.com/open-gitops/project)
+- [GitOps Working Group](https://github.com/cncf/tag-app-delivery/tree/master/gitops-wg)
 
 ## Communication
 
 - To report security vulnerabilities, please see [SECURITY.md](SECURITY.md)
-- To connect with the GitHub Working Group – including Reddit, Slack, public email list, GitHub issues, and in-person meeting info – see [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved).
+- To contribute to OpenGitOps, see [CONTRIBUTING.md](CONTRIBUTING.md)
+- To connect with the GitHub Working Group – including in-person meetings, Slack, public email list, and social media – see [Community](https://github.com/cncf/tag-app-delivery/tree/master/gitops-wg#community)
 - For all other issues, please open a GitHub issue in the appropriate OpenGitOps repository.
   If you are unsure which repository to add the issue you may email the OpenGitOps private maintainers list <cncf-opengitops-maintainers@lists.cncf.io> and we'll do our best to help direct you 🙂


### PR DESCRIPTION
Part of properly moving appropriate files and content from https://github.com/gitops-working-group/gitops-working-group to https://github.com/open-gitops.

- Fixes: https://github.com/open-gitops/.github/issues/3
- Also see https://github.com/cncf/tag-app-delivery/pull/146