### PR TITLE
Update Contributing Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@
 <img src="https://openmoji.org/data/color/svg/1F91D.svg" alt="Handshake emoji Unicode 1F91D. OpenMoji CC BY-SA 4.0" width="150" valign="middle"></p>
 
 There are many ways to contribute to OpenGitOps.
-See [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved) in the GitOps WG.
+See [How to Get Involved](https://opengitops.dev/get-involved) in the GitOps WG.


### PR DESCRIPTION
How to get involved link sends users through a loop. 

It may or maynot be the "right link" but this change is better than sending users through a loop.