### PR TITLE
Chore: Add README to organisation overview page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,36 @@
+# OpenGitOps
+<!-- markdownlint-disable MD033 -->
+<p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150"></p>
+
+Welcome!
+OpenGitOps is a [CNCF Sandbox project](https://www.cncf.io/sandbox-projects/) to define a vendor-neutral, principle-led meaning of GitOps.
+This will establish a foundation for interoperability between tools, conformance, and certification through lasting programs, documents, and code.
+
+## Repositories
+
+<!-- markdownlint-disable MD033 -->
+| | Name | Description |
+| -- | -- | -- |
+| <img src="https://openmoji.org/data/color/svg/1F4D1.svg" alt="Bookmark Tabs emoji Unicode 1F4D1. OpenMoji CC BY-SA 4.0" width="100"> | [documents](https://github.com/open-gitops/documents) |  Lasting documents for the OpenGitOps project, which are versioned and released together (including the GitOps [Principles](https://github.com/open-gitops/documents/blob/v0.1.0/PRINCIPLES.md) and [Glossary](https://github.com/open-gitops/documents/blob/v0.1.0/PRINCIPLES.md#glossary)) |
+| <img src="https://openmoji.org/data/color/svg/1F4C5.svg" alt="Calendar emoji Unicode 1F4C5. OpenMoji CC BY-SA 4.0" width="100"> | [events](https://github.com/open-gitops/events) | A repo for GitOps community events (currently events either organized or curated by the GitOps WG Events Committee) |
+| <img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="100"> | [project](https://github.com/open-gitops/project) | Top-level information about the OpenGitOps project (this repo) |
+| <img src="https://openmoji.org/data/color/svg/1F310.svg" alt="Globe with Meridians emoji Unicode 1F310. OpenMoji CC BY-SA 4.0" width="100"> | [website](https://github.com/open-gitops/website) | Source code for OpenGitOps website |
+| <img src="https://openmoji.org/data/color/svg/1F9D1-200D-2695-FE0F.svg" alt="Health Worker Unicode 1F9D1-200D-2695-FE0F. OpenMoji CC BY-SA 4.0" width="100"> | [.github](https://github.com/open-gitops/.github) | Organization-wide [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for all OpenGitOps project repos |
+
+## Contributing
+
+Be sure to review the OpenGitOps [contributing guidelines](https://github.com/open-gitops/.github/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/open-gitops/.github/blob/main/CODE_OF_CONDUCT.md).
+
+OpenGitOps is currently guided by the CNCF [GitOps Working Group](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg), a WG under the CNCF [App Delivery TAG](https://github.com/cncf/tag-app-delivery).
+It is an open public working group welcoming anyone who would like to join and help.
+See [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved).
+
+## Security
+
+Reporting a security vulnerability?
+Check out the project's [security policy](https://github.com/open-gitops/.github/blob/main/SECURITY.md).
+
+## Support
+
+Looking for help?
+Check out the project’s [instructions for getting support](https://github.com/open-gitops/.github/blob/main/SUPPORT.md).


### PR DESCRIPTION
As discussed in the wednesday meeting this PR adds a README to the organisation's GitHub [overview page](https://github.com/open-gitops)