### PR TITLE
Update open-gitops profile from project README again

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,6 +2,8 @@
 <!-- markdownlint-disable MD033 -->
 <p><img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opengitops/icon/color/opengitops-icon-color.svg" alt="OpenGitOps logo icon color" width="150"></p>
 
+## Mission
+
 Welcome!
 OpenGitOps is a [CNCF Sandbox project](https://www.cncf.io/sandbox-projects/) to define a vendor-neutral, principle-led meaning of GitOps.
 This will establish a foundation for interoperability between tools, conformance, and certification through lasting programs, documents, and code.
@@ -19,11 +21,8 @@ This will establish a foundation for interoperability between tools, conformance
 
 ## Contributing
 
+OpenGitOps is an open public project welcoming anyone who would like to get involved.
 Be sure to review the OpenGitOps [contributing guidelines](https://github.com/open-gitops/.github/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/open-gitops/.github/blob/main/CODE_OF_CONDUCT.md).
-
-OpenGitOps is currently guided by the CNCF [GitOps Working Group](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg), a WG under the CNCF [App Delivery TAG](https://github.com/cncf/tag-app-delivery).
-It is an open public working group welcoming anyone who would like to join and help.
-See [How to Get Involved](https://github.com/gitops-working-group/gitops-working-group/blob/main/README.md#how-to-get-involved).
 
 ## Security
 


### PR DESCRIPTION
Some fixed links and other improvements in open-gitops/project README.md since the last sync

## Follow-up
- [ ] To-do: automate syncing this file whenever open-gitops/project README.md is updated